### PR TITLE
SE-3125/added DB layer to extract data from NSRDB collection

### DIFF
--- a/src/helpers/sam.ts
+++ b/src/helpers/sam.ts
@@ -34,7 +34,13 @@ export const ensureWeatherFileOnS3AndDownloadLocally = async (
   let weatherFileResponseBody = await getWeatherDataFromNSRDB(latLonObj.lt, latLonObj.ln);
 
   if (!weatherFileResponseBody) {
-    return Promise.reject(new Error('weather data not found'));
+    const resp = await ctx.NSRDBSolarWeatherRepository.getNearestWeatherData(
+      latLonObj.lt.toString(),
+      latLonObj.ln.toString()
+    );
+
+    const { data } = await axios.get(resp.s3File);
+    weatherFileResponseBody = data;
   }
 
   const weatherDataRecords: [][] = await new Promise((resolve, reject) => {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,9 +1,11 @@
 import { BaseModel } from './base-model';
 import { CONSTANTS as MODEL_CONSTANTS } from './constant';
+import { NSRDBSolarWeather } from './nsrdb-solar-weather';
 import { ModelFactory } from './model-factory';
 
 export {
   BaseModel,
   ModelFactory,
+  NSRDBSolarWeather,
   MODEL_CONSTANTS
 };

--- a/src/models/location.ts
+++ b/src/models/location.ts
@@ -1,0 +1,33 @@
+import { LooseObject } from '@typings';
+import { BaseModel } from './base-model';
+
+export class Location extends BaseModel {
+  type: string;
+  lat?: number;
+  lon?: number;
+  coordinates?: number[];
+
+  constructor(json?: any) {
+    super(json);
+    if (json) {
+      this.type = json.type;
+      this.lon = json.lon || json.coordinates[0];
+      this.lat = json.lat || json.coordinates[1];
+    }
+  }
+
+  public toSchema(): Location {
+    this.coordinates = [this.lon, this.lat];
+    delete this.lat;
+    delete this.lon;
+    return this;
+  }
+
+  public serialize(): LooseObject {
+    return {
+      type: this.type,
+      lat: this.lat,
+      lon: this.lon
+    };
+  }
+}

--- a/src/models/nsrdb-solar-weather.ts
+++ b/src/models/nsrdb-solar-weather.ts
@@ -1,0 +1,31 @@
+import { LooseObject } from '@typings';
+import { BaseModel } from './base-model';
+import { Location } from './location';
+
+export class NSRDBSolarWeather extends BaseModel {
+  loc: Location;
+  locationId: string;
+  s3File: string;
+
+  constructor(json?: any) {
+    super(json);
+    if (json) {
+      this.loc = new Location(json.loc);
+      this.locationId = json.locationId;
+      this.s3File = json.s3File;
+    }
+  }
+
+  public toSchema(): NSRDBSolarWeather {
+    this.loc = this.loc.toSchema();
+    return this;
+  }
+
+  public serialize(): LooseObject {
+    return {
+      loc: this.loc.serialize(),
+      locationId: this.locationId,
+      s3File: this.s3File
+    };
+  }
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -18,6 +18,7 @@ const repositoryContext = {
 
 const appContext: AppContext = {
   logger,
+  NSRDBSolarWeatherRepository: new Repositories.NSRDBSolarWeatherRepository(repositoryContext),
 };
 
 mongoStore

--- a/src/storage/mongoose/index.ts
+++ b/src/storage/mongoose/index.ts
@@ -1,5 +1,7 @@
 import { MongoStore } from './mongo-store';
+import NSRDBSolarWeather from './nsrdb-solar-weather';
 
 export {
   MongoStore,
+  NSRDBSolarWeather
 };

--- a/src/storage/mongoose/mongo-store.ts
+++ b/src/storage/mongoose/mongo-store.ts
@@ -3,6 +3,8 @@ import { DeleteResult, IDataStore, QueryOptions } from '@storage';
 import { LooseObject } from '@typings';
 import config from 'config';
 import { connect, ConnectionOptions, Document, Model as MongoosModel, Mongoose, Types } from 'mongoose';
+import NSRDBSolarWeather from './nsrdb-solar-weather';
+import { REPOSITORY_CONSTANTS } from '../repositories';
 
 export class MongoStore implements IDataStore {
   public connect(): Promise<Mongoose> {
@@ -197,6 +199,9 @@ export class MongoStore implements IDataStore {
   }
 
   private getModel<T extends BaseModel>(modelFactory: ModelFactory<T>): MongoosModel<Document> {
+    if (modelFactory.getType() === REPOSITORY_CONSTANTS.REPOSITORY_TYPE.NSRDB_SOLAR_WEATHER) {
+      return NSRDBSolarWeather;
+    }
     return null;
   }
 }

--- a/src/storage/mongoose/nsrdb-solar-weather.ts
+++ b/src/storage/mongoose/nsrdb-solar-weather.ts
@@ -1,0 +1,23 @@
+import { model, Schema } from 'mongoose';
+
+const NSRDBSolarWeatherSchema: Schema = new Schema(
+  {
+    loc: {
+      type: { type: Schema.Types.String, required: true },
+      coordinates: [{ type: Schema.Types.Number, required: true }]
+    },
+    locationId: { type: String, required: true },
+    s3File: { type: String, required: true }
+  },
+  {
+    collection: 'nsrdb_solar_weather',
+    timestamps: {
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt'
+    }
+  }
+);
+
+NSRDBSolarWeatherSchema.index({ loc: '2dsphere' });
+const NSRDBSolarWeather = model('NSRDBSolarWeather', NSRDBSolarWeatherSchema);
+export default NSRDBSolarWeather;

--- a/src/storage/repositories/constant.ts
+++ b/src/storage/repositories/constant.ts
@@ -1,1 +1,5 @@
-export const CONSTANTS = {};
+export const CONSTANTS = {
+  REPOSITORY_TYPE: {
+    NSRDB_SOLAR_WEATHER: 'NSRDBSolarWeather'
+  }
+};

--- a/src/storage/repositories/index.ts
+++ b/src/storage/repositories/index.ts
@@ -1,4 +1,7 @@
 import { CONSTANTS as REPOSITORY_CONSTANTS } from './constant';
+import { NSRDBSolarWeatherRepository } from './nsrdb-solar-weather-repository';
+
 export {
-  REPOSITORY_CONSTANTS
+  REPOSITORY_CONSTANTS,
+  NSRDBSolarWeatherRepository
 };

--- a/src/storage/repositories/nsrdb-solar-weather-repository.ts
+++ b/src/storage/repositories/nsrdb-solar-weather-repository.ts
@@ -1,0 +1,50 @@
+import { ModelFactory, NSRDBSolarWeather } from '@models';
+import { LooseObject } from '@typings';
+import { BaseRepository } from './base-repository';
+import { CONSTANTS } from './constant';
+import { RepositoryContext } from './repository-context';
+
+export class NSRDBSolarWeatherRepository extends BaseRepository<NSRDBSolarWeather> {
+  constructor(context: RepositoryContext) {
+    super(context);
+  }
+
+  public async getNearestWeatherData(lat: string, lon: string): Promise<LooseObject> {
+    const geospatialQuery = {
+      loc: {
+        $near: {
+          $geometry: {
+            type: 'Point',
+            coordinates: [lon, lat]
+          }
+        }
+      }
+    };
+
+    const queryOptions = {
+      skip: 0,
+      limit: 1
+    };
+
+    const [result] = await this.context.store.getAll<NSRDBSolarWeather>(
+      {
+        ...geospatialQuery
+      },
+      queryOptions,
+      this.modelFactory()
+    );
+
+    return result.serialize();
+  }
+
+  protected modelFactory(): ModelFactory<NSRDBSolarWeather> {
+    return {
+      getType() {
+        return CONSTANTS.REPOSITORY_TYPE.NSRDB_SOLAR_WEATHER;
+      },
+      create(json: any) {
+        return new NSRDBSolarWeather(json);
+      }
+    };
+  }
+}

--- a/src/typings/app-context.ts
+++ b/src/typings/app-context.ts
@@ -1,5 +1,7 @@
 import { Logger } from '@typings';
+import { Repositories } from '@storage';
 
 export type AppContext = {
   logger: Logger;
+  NSRDBSolarWeatherRepository: Repositories.NSRDBSolarWeatherRepository;
 };

--- a/test/mocks/app-context.ts
+++ b/test/mocks/app-context.ts
@@ -1,3 +1,4 @@
+import { Repositories } from '@storage';
 import { AppContext } from '@typings';
 import { InMemoryMongoStore } from './in-memory-mongo-store';
 import { MockLogger } from './mock-logger';
@@ -12,5 +13,6 @@ export const repositoryContext = {
 };
 
 export const testAppContext: AppContext = {
-  logger: mockLogger
+  logger: mockLogger,
+  NSRDBSolarWeatherRepository: new Repositories.NSRDBSolarWeatherRepository(repositoryContext),
 };


### PR DESCRIPTION
## Description
When we are trying to fetch weather data for PV-watts calculation, we first look for weather report locally. If not found, we check for it on AWS. If not found there as well, We try to fetch this data from NREL servers. And if nothing works we find nearest location to that address for which we have the weather report. In this case, the final link was broken. That's why system was not allowing to add data from new zipcode.

## Database schema changes
N/A

## Tests
### Automated test cases added
TBD

### Manual test cases run
- manually tested using postman and test cases